### PR TITLE
refactor: tidying types in virtual module

### DIFF
--- a/.changeset/famous-insects-judge.md
+++ b/.changeset/famous-insects-judge.md
@@ -1,0 +1,6 @@
+---
+"astro-simple-feature-flags": patch
+---
+
+Refactor types in virtual module
+  

--- a/packages/astro-simple-feature-flags/src/virtual-module/templates/declaration.d.ts
+++ b/packages/astro-simple-feature-flags/src/virtual-module/templates/declaration.d.ts
@@ -2,19 +2,21 @@
 // @ts-nocheck
 
 declare module "@@__VIRTUAL_MODULE_ID__@@" {
-  type Module = typeof import("@@__CONFIG_MODULE_ID__@@");
+  type FeatureFlagConfig = GetExport<
+    typeof import("@@__CONFIG_MODULE_ID__@@"),
+    "default"
+  >;
 
-  type ResolvedFlags = GetExport<Module, "default">;
+  type FeatureFlagShape = import("astro/zod").output<
+    FeatureFlagConfig["schema"]
+  >;
 
-  type FlagSchema = ResolvedFlags["schema"];
-  type FlagOutputShape = import("astro/zod").output<FlagSchema>;
-  type FlagKey = keyof FlagOutputShape;
+  export type FeatureFlagKey = keyof FeatureFlagShape;
 
-  type QueryFlag<TKey extends FlagKey> = TKey extends FlagKey
-    ? FlagOutputShape[TKey]
-    : never;
+  type QueryFeatureFlag<TKey extends FeatureFlagKey> =
+    TKey extends FeatureFlagKey ? FeatureFlagShape[TKey] : never;
 
-  export function queryFeatureFlag<TKey extends FlagKey>(
+  export function queryFeatureFlag<TKey extends FeatureFlagKey>(
     flag: TKey,
-  ): Promise<QueryFlag<TKey>>;
+  ): Promise<QueryFeatureFlag<TKey>>;
 }


### PR DESCRIPTION
Since all definition in `declare module` is marked as exported,
I should tidying and naming types properly.