### PR TITLE
test: add e2e for generated `.d.ts` files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,25 +33,9 @@ $ tree --gitignore -d -L 2
 
 - `pnpm lint` - Run lint for all packages
 - `pnpm test` - Run Vitest tests
+  - You need to run `pnpm build` first to generate types
 - `pnpm format` - Apply Biome formatting
 - `pnpm typecheck` - Run type checking for all packages
-
-### Package Directory (`packages/astro-simple-feature-flags/`)
-
-expected cwd: repository root
-
-- `pnpm --filter astro-simple-feature-flags build` - Build with tsdown
-- `pnpm --filter astro-simple-feature-flags test` - Run Vitest tests
-- `pnpm --filter astro-simple-feature-flags lint` - Run ESLint
-- `pnpm --filter astro-simple-feature-flags typecheck` - Run TypeScript type checking
-
-### Playground (`playgrounds/simple-flag/`)
-
-expected cwd: repository root
-
-- `pnpm --filter @repo/playgrounds-simple-flag dev` - Start development server (localhost:4321)
-- `pnpm --filter @repo/playgrounds-simple-flag build` - Production build
-- `pnpm --filter @repo/playgrounds-simple-flag preview` - Preview build
 
 ## Package Management
 

--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
     "test": "vitest --run",
     "format": "biome format --write .",
     "typecheck": "pnpm -r run typecheck",
-    "build": "pnpm run build:astro-simple-feature-flags && pnpm run build:e2e",
+    "build": "pnpm run build:astro-simple-feature-flags && pnpm run build:e2e && pnpm run build:e2e-dts",
     "build:astro-simple-feature-flags": "pnpm --filter astro-simple-feature-flags run build",
     "build:e2e": "pnpm --filter e2e run build",
+    "build:e2e-dts": "pnpm --filter e2e-dts run build",
     "pkg-pr-new": "pkg-pr-new publish --compact --comment=update --pnpm",
     "release": "pnpm run build && changeset publish",
     "changeset": "changeset"

--- a/packages/astro-simple-feature-flags/src/virtual-module/templates/declaration.d.ts
+++ b/packages/astro-simple-feature-flags/src/virtual-module/templates/declaration.d.ts
@@ -13,10 +13,11 @@ declare module "@@__VIRTUAL_MODULE_ID__@@" {
 
   export type FeatureFlagKey = keyof FeatureFlagShape;
 
-  type QueryFeatureFlag<TKey extends FeatureFlagKey> =
-    TKey extends FeatureFlagKey ? FeatureFlagShape[TKey] : never;
+  type QueryFeatureFlag<TKey extends string> = TKey extends FeatureFlagKey
+    ? FeatureFlagShape[TKey]
+    : void;
 
-  export function queryFeatureFlag<TKey extends FeatureFlagKey>(
-    flag: TKey,
-  ): Promise<QueryFeatureFlag<TKey>>;
+  export function queryFeatureFlag<
+    TKey extends FeatureFlagKey | AnyStringLiteral,
+  >(flag: TKey): Promise<QueryFeatureFlag<TKey>>;
 }

--- a/packages/astro-simple-feature-flags/src/virtual-module/templates/declaration.d.ts
+++ b/packages/astro-simple-feature-flags/src/virtual-module/templates/declaration.d.ts
@@ -7,14 +7,14 @@ declare module "@@__VIRTUAL_MODULE_ID__@@" {
     "default"
   >;
 
-  type FeatureFlagShape = import("astro/zod").output<
+  type FeatureFlagDataShape = import("astro/zod").output<
     FeatureFlagConfig["schema"]
   >;
 
-  export type FeatureFlagKey = keyof FeatureFlagShape;
+  export type FeatureFlagKey = keyof FeatureFlagDataShape;
 
   type QueryFeatureFlag<TKey extends FeatureFlagKey> =
-    TKey extends FeatureFlagKey ? FeatureFlagShape[TKey] : never;
+    TKey extends FeatureFlagKey ? FeatureFlagDataShape[TKey] : never;
 
   export function queryFeatureFlag<TKey extends FeatureFlagKey>(
     flag: TKey,

--- a/packages/astro-simple-feature-flags/src/virtual-module/templates/declaration.d.ts
+++ b/packages/astro-simple-feature-flags/src/virtual-module/templates/declaration.d.ts
@@ -13,11 +13,10 @@ declare module "@@__VIRTUAL_MODULE_ID__@@" {
 
   export type FeatureFlagKey = keyof FeatureFlagShape;
 
-  type QueryFeatureFlag<TKey extends string> = TKey extends FeatureFlagKey
-    ? FeatureFlagShape[TKey]
-    : void;
+  type QueryFeatureFlag<TKey extends FeatureFlagKey> =
+    TKey extends FeatureFlagKey ? FeatureFlagShape[TKey] : never;
 
-  export function queryFeatureFlag<
-    TKey extends FeatureFlagKey | AnyStringLiteral,
-  >(flag: TKey): Promise<QueryFeatureFlag<TKey>>;
+  export function queryFeatureFlag<TKey extends FeatureFlagKey>(
+    flag: TKey,
+  ): Promise<QueryFeatureFlag<TKey>>;
 }

--- a/packages/astro-simple-feature-flags/src/virtual-module/templates/internal.d.ts
+++ b/packages/astro-simple-feature-flags/src/virtual-module/templates/internal.d.ts
@@ -6,4 +6,6 @@ declare module "@@__VIRTUAL_MODULE_ID__@@" {
     TMod extends Record<string, unknown>,
     TKey extends string,
   > = TKey extends keyof TMod ? TMod[TKey] : never;
+
+  type AnyStringLiteral = string & Record<never, never>;
 }

--- a/packages/astro-simple-feature-flags/src/virtual-module/templates/internal.d.ts
+++ b/packages/astro-simple-feature-flags/src/virtual-module/templates/internal.d.ts
@@ -6,6 +6,4 @@ declare module "@@__VIRTUAL_MODULE_ID__@@" {
     TMod extends Record<string, unknown>,
     TKey extends string,
   > = TKey extends keyof TMod ? TMod[TKey] : never;
-
-  type AnyStringLiteral = string & Record<never, never>;
 }

--- a/packages/e2e-dts/.gitignore
+++ b/packages/e2e-dts/.gitignore
@@ -1,0 +1,24 @@
+# build output
+dist/
+# generated types
+.astro/
+
+# dependencies
+node_modules/
+
+# logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+
+# environment variables
+.env
+.env.production
+
+# macOS-specific files
+.DS_Store
+
+# jetbrains setting folder
+.idea/

--- a/packages/e2e-dts/README.md
+++ b/packages/e2e-dts/README.md
@@ -1,0 +1,43 @@
+# Astro Starter Kit: Minimal
+
+```sh
+pnpm create astro@latest -- --template minimal
+```
+
+> 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
+
+## 🚀 Project Structure
+
+Inside of your Astro project, you'll see the following folders and files:
+
+```text
+/
+├── public/
+├── src/
+│   └── pages/
+│       └── index.astro
+└── package.json
+```
+
+Astro looks for `.astro` or `.md` files in the `src/pages/` directory. Each page is exposed as a route based on its file name.
+
+There's nothing special about `src/components/`, but that's where we like to put any Astro/React/Vue/Svelte/Preact components.
+
+Any static assets, like images, can be placed in the `public/` directory.
+
+## 🧞 Commands
+
+All commands are run from the root of the project, from a terminal:
+
+| Command                   | Action                                           |
+| :------------------------ | :----------------------------------------------- |
+| `pnpm install`             | Installs dependencies                            |
+| `pnpm dev`             | Starts local dev server at `localhost:4321`      |
+| `pnpm build`           | Build your production site to `./dist/`          |
+| `pnpm preview`         | Preview your build locally, before deploying     |
+| `pnpm astro ...`       | Run CLI commands like `astro add`, `astro check` |
+| `pnpm astro -- --help` | Get help using the Astro CLI                     |
+
+## 👀 Want to learn more?
+
+Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).

--- a/packages/e2e-dts/astro.config.mjs
+++ b/packages/e2e-dts/astro.config.mjs
@@ -1,0 +1,8 @@
+// @ts-check
+import simpleFeatureFlags from "astro-simple-feature-flags";
+import { defineConfig } from "astro/config";
+
+// https://astro.build/config
+export default defineConfig({
+  integrations: [simpleFeatureFlags()],
+});

--- a/packages/e2e-dts/eslint.config.js
+++ b/packages/e2e-dts/eslint.config.js
@@ -1,0 +1,4 @@
+import ts from "@virtual-live-lab/eslint-config/presets/ts";
+import { defineConfig } from "eslint/config";
+
+export default defineConfig(ts);

--- a/packages/e2e-dts/flags.config.ts
+++ b/packages/e2e-dts/flags.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from "astro-simple-feature-flags/config";
+import { z } from "astro/zod";
+
+export default defineConfig({
+  flag: {
+    development: {
+      barReleaseRate: 1,
+      fooReleased: true,
+    },
+
+    staging: {
+      barReleaseRate: 0.5,
+      fooReleased: true,
+    },
+
+    production: {},
+  },
+  schema: z.object({
+    barReleaseRate: z.number().min(0).max(1).optional().default(0),
+    fooReleased: z.boolean().optional().default(false),
+  }),
+  viteMode: ["development", "production", "staging"],
+});

--- a/packages/e2e-dts/package.json
+++ b/packages/e2e-dts/package.json
@@ -21,7 +21,6 @@
     "vitest": "catalog:test"
   },
   "dependencies": {
-    "@astrojs/node": "9.3.3",
     "astro": "^5.0.0",
     "astro-simple-feature-flags": "workspace:*"
   }

--- a/packages/e2e-dts/package.json
+++ b/packages/e2e-dts/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@repo/e2e-dts",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "lint": "eslint --max-warnings 0 --fix .",
+    "format": "biome format --write .",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest --run",
+    "build": "astro build"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "catalog:biome",
+    "@types/node": "24.1.0",
+    "@virtual-live-lab/eslint-config": "catalog:eslint",
+    "@virtual-live-lab/tsconfig": "catalog:typescript",
+    "eslint": "catalog:eslint",
+    "typescript": "catalog:typescript",
+    "typescript-eslint": "catalog:eslint",
+    "vitest": "catalog:test"
+  },
+  "dependencies": {
+    "@astrojs/node": "9.3.3",
+    "astro": "^5.0.0",
+    "astro-simple-feature-flags": "workspace:*"
+  }
+}

--- a/packages/e2e-dts/src/content/config.ts
+++ b/packages/e2e-dts/src/content/config.ts
@@ -1,0 +1,5 @@
+import { defineFeatureFlagCollection } from "astro-simple-feature-flags/content-layer";
+
+export const collections = {
+  ...defineFeatureFlagCollection(),
+};

--- a/packages/e2e-dts/src/pages/index.astro
+++ b/packages/e2e-dts/src/pages/index.astro
@@ -1,0 +1,16 @@
+---
+
+---
+
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+		<meta name="viewport" content="width=device-width" />
+		<meta name="generator" content={Astro.generator} />
+		<title>Astro</title>
+	</head>
+	<body>
+		<h1>Astro</h1>
+	</body>
+</html>

--- a/packages/e2e-dts/src/pages/index.astro
+++ b/packages/e2e-dts/src/pages/index.astro
@@ -1,5 +1,7 @@
 ---
+import { queryFeatureFlag } from "virtual:astro-simple-feature-flags";
 
+const barReleaseRate = await queryFeatureFlag("barReleaseRate");
 ---
 
 <html lang="en">
@@ -12,5 +14,6 @@
 	</head>
 	<body>
 		<h1>Astro</h1>
+		<p>Current barReleaseRate: {barReleaseRate}</p>
 	</body>
 </html>

--- a/packages/e2e-dts/tests/virtual-mod.test-d.ts
+++ b/packages/e2e-dts/tests/virtual-mod.test-d.ts
@@ -1,18 +1,18 @@
 // CAUTION: Vitest's typecheck mode does not run any setup codes in test files or setup files.
 // This means WE MUST run `astro build` or `astro sync` before running this test file.
 
-import type { queryFeatureFlag } from "virtual:astro-simple-feature-flags";
 import type {
+  FeatureFlagDataShape,
   FeatureFlagKey,
-  FeatureFlagShape,
+  queryFeatureFlag,
 } from "virtual:astro-simple-feature-flags";
 
 import { describe, expectTypeOf, it } from "vitest";
 
-describe("Generated dts of virtual:astro-simple-feature-flags", () => {
-  describe("FeatureFlagShape", () => {
+describe("types of virtual:astro-simple-feature-flags", () => {
+  describe("FeatureFlagDataShape", () => {
     it("should be the output type of the feature flag schema", () => {
-      expectTypeOf<FeatureFlagShape>().toEqualTypeOf<{
+      expectTypeOf<FeatureFlagDataShape>().toEqualTypeOf<{
         barReleaseRate: number;
         fooReleased: boolean;
       }>();
@@ -36,12 +36,6 @@ describe("Generated dts of virtual:astro-simple-feature-flags", () => {
       expectTypeOf<
         ReturnType<typeof queryFeatureFlag<"fooReleased">>
       >().toEqualTypeOf<Promise<boolean>>();
-    });
-
-    it("should return a promise of void for an invalid key", () => {
-      expectTypeOf<
-        ReturnType<typeof queryFeatureFlag<"invalidKey">>
-      >().toEqualTypeOf<Promise<void>>();
     });
   });
 });

--- a/packages/e2e-dts/tests/virtual-mod.test-d.ts
+++ b/packages/e2e-dts/tests/virtual-mod.test-d.ts
@@ -1,0 +1,47 @@
+// CAUTION: Vitest's typecheck mode does not run any setup codes in test files or setup files.
+// This means WE MUST run `astro build` or `astro sync` before running this test file.
+
+import type { queryFeatureFlag } from "virtual:astro-simple-feature-flags";
+import type {
+  FeatureFlagKey,
+  FeatureFlagShape,
+} from "virtual:astro-simple-feature-flags";
+
+import { describe, expectTypeOf, it } from "vitest";
+
+describe("Generated dts of virtual:astro-simple-feature-flags", () => {
+  describe("FeatureFlagShape", () => {
+    it("should be the output type of the feature flag schema", () => {
+      expectTypeOf<FeatureFlagShape>().toEqualTypeOf<{
+        barReleaseRate: number;
+        fooReleased: boolean;
+      }>();
+    });
+  });
+
+  describe("FeatureFlagKey", () => {
+    it("should be a union of keys from the feature flag schema", () => {
+      expectTypeOf<FeatureFlagKey>().toEqualTypeOf<
+        "barReleaseRate" | "fooReleased"
+      >();
+    });
+  });
+
+  describe("queryFeatureFlag", () => {
+    it("should return a promise of the queried feature flag type", () => {
+      expectTypeOf<
+        ReturnType<typeof queryFeatureFlag<"barReleaseRate">>
+      >().toEqualTypeOf<Promise<number>>();
+
+      expectTypeOf<
+        ReturnType<typeof queryFeatureFlag<"fooReleased">>
+      >().toEqualTypeOf<Promise<boolean>>();
+    });
+
+    it("should return a promise of void for an invalid key", () => {
+      expectTypeOf<
+        ReturnType<typeof queryFeatureFlag<"invalidKey">>
+      >().toEqualTypeOf<Promise<void>>();
+    });
+  });
+});

--- a/packages/e2e-dts/tsconfig.json
+++ b/packages/e2e-dts/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "astro/tsconfigs/strict",
+  "include": [".astro/types.d.ts", "**/*"],
+  "exclude": ["dist"]
+}

--- a/packages/e2e-dts/vitest.config.ts
+++ b/packages/e2e-dts/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    typecheck: {
+      enabled: true,
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,6 +174,43 @@ importers:
         specifier: catalog:test
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.1.0)(jiti@2.5.1)(yaml@2.8.0)
 
+  packages/e2e-dts:
+    dependencies:
+      '@astrojs/node':
+        specifier: 9.3.3
+        version: 9.3.3(astro@5.12.8(@types/node@24.1.0)(jiti@2.5.1)(rollup@4.46.2)(typescript@5.8.3)(yaml@2.8.0))
+      astro:
+        specifier: ^5.0.0
+        version: 5.12.8(@types/node@24.1.0)(jiti@2.5.1)(rollup@4.46.2)(typescript@5.8.3)(yaml@2.8.0)
+      astro-simple-feature-flags:
+        specifier: workspace:*
+        version: link:../astro-simple-feature-flags
+    devDependencies:
+      '@biomejs/biome':
+        specifier: catalog:biome
+        version: 2.1.2
+      '@types/node':
+        specifier: 24.1.0
+        version: 24.1.0
+      '@virtual-live-lab/eslint-config':
+        specifier: catalog:eslint
+        version: 2.2.24(@typescript-eslint/parser@8.38.0(eslint@9.31.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.31.0(jiti@2.5.1))(tailwindcss@3.4.17)(typescript@5.8.3)
+      '@virtual-live-lab/tsconfig':
+        specifier: catalog:typescript
+        version: 2.1.21(typescript@5.8.3)
+      eslint:
+        specifier: catalog:eslint
+        version: 9.31.0(jiti@2.5.1)
+      typescript:
+        specifier: catalog:typescript
+        version: 5.8.3
+      typescript-eslint:
+        specifier: catalog:eslint
+        version: 8.38.0(eslint@9.31.0(jiti@2.5.1))(typescript@5.8.3)
+      vitest:
+        specifier: catalog:test
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.1.0)(jiti@2.5.1)(yaml@2.8.0)
+
   playgrounds/simple-flag:
     dependencies:
       astro:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,9 +176,6 @@ importers:
 
   packages/e2e-dts:
     dependencies:
-      '@astrojs/node':
-        specifier: 9.3.3
-        version: 9.3.3(astro@5.12.8(@types/node@24.1.0)(jiti@2.5.1)(rollup@4.46.2)(typescript@5.8.3)(yaml@2.8.0))
       astro:
         specifier: ^5.0.0
         version: 5.12.8(@types/node@24.1.0)(jiti@2.5.1)(rollup@4.46.2)(typescript@5.8.3)(yaml@2.8.0)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new package for end-to-end type testing with feature flag support and Astro integration.
  * Added a sample Astro page and feature flag configuration for demonstration and testing.
  * Provided a content layer integration and initial project setup with documentation.

* **Bug Fixes**
  * Broadened feature flag query support to accept any string key, returning void for unknown flags.

* **Documentation**
  * Added comprehensive README and configuration guides for the new package.

* **Tests**
  * Implemented type-level tests to validate feature flag typings and query behavior.

* **Chores**
  * Updated build scripts to include the new package. 
  * Added configuration files for TypeScript, ESLint, Vitest, and .gitignore.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->