### PR TITLE
ci: pin node22 to 22.12.0, drop node25, add node26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ["22.x", "24.x", "25.x"]
+        node-version: ["22.12.0", "24.x", "26.x"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
ref: https://endoflife.date/nodejs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to test against specific Node.js versions (22.12.0, 24.x, 26.x) for improved compatibility verification.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sushichan044/astro-simple-feature-flags/pull/44)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->